### PR TITLE
Trix(リッチテキスト表示不具合解消。原因不明だがクローン後yarn add trix、その後種々の設定で解決)

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -7,6 +7,8 @@ import Rails from "@rails/ujs"
 import Turbolinks from "turbolinks"
 import * as ActiveStorage from "@rails/activestorage"
 import "channels"
+import * as Trix from "trix";
+import '../src/application.css';
 
 Rails.start()
 Turbolinks.start()

--- a/app/javascript/src/application.css
+++ b/app/javascript/src/application.css
@@ -1,0 +1,1 @@
+@import 'trix/dist/trix';

--- a/app/views/documents/_form.html.erb
+++ b/app/views/documents/_form.html.erb
@@ -18,7 +18,8 @@
 
   <div class="field">
     <%= form.label :content %>
-    <%= form.text_area :content %>
+    <%= form.hidden_field :content %>
+    <trix-editor input="document_content" class="trix-content">
   </div>
 
   <div class="field">

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@rails/ujs": "^6.0.0",
     "@rails/webpacker": "5.4.4",
     "rails_admin": "3.1.1",
+    "trix": "^2.0.4",
     "turbolinks": "^5.2.0",
     "webpack": "^4.46.0",
     "webpack-cli": "^3.3.12"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6767,6 +6767,11 @@ toidentifier@1.0.1:
   resolved "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz"
   integrity sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==
 
+trix@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/trix/-/trix-2.0.4.tgz#37ec8092e5d561462cee1d96cc402aa5c5f8c04e"
+  integrity sha512-WOMKqwCVti0i3RVaDrMnrEZWs6XMpFoCfUvFCZNd15KndAy6MsYQscizxEpFiCLUlo+rXMkueK0ldRDo5xpVJA==
+
 ts-pnp@^1.1.6:
   version "1.2.0"
   resolved "https://registry.npmjs.org/ts-pnp/-/ts-pnp-1.2.0.tgz"


### PR DESCRIPTION
- Trixで大苦戦。結局原因はわからず。
- ローカルでgemやyarnが複雑に絡み合った結果生じた不具合かと推測し、一度GitHubにプッシュしたのち、クローンしてローカルでyarn installし、その後種々の設定をしたら無事完了。
- 原因がはっきりしないが、経験知として一応記録。
- 以下にクローン後の手順を示す
$ yarn add trix
/app/views/documents/_form.html.erb
<div class="field">
     <%= form.label :content %>
-    <%= form.text_area :content %>
+    <%= form.hidden_field :content %>
+    <trix-editor input="document_content" class="trix-content"></trix-editor>
   </div>

app/javascript/packs/application.js
  import * as Trix from "trix";
  import '../src/application.css';

app/javascript/src/application.css
  [@import](http://twitter.com/import) 'trix/dist/trix';
リッチテキストが表示されたことを確認したのちbundle install